### PR TITLE
Refactor the architecture for new PECO application

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML==5.3.1
 termcolor==1.1.0
+more-itertools==8.10.0

--- a/src/config.py
+++ b/src/config.py
@@ -1,12 +1,11 @@
 import os
-from os import path
 import yaml
 
 class Config():
     def __init__(self, config_file):
         self.config_file = config_file
 
-        if path.isfile(config_file):
+        if os.path.isfile(config_file):
             with open(config_file, 'r') as f:
                 self.config = yaml.safe_load(f)
         else:
@@ -36,7 +35,7 @@ class Config():
             if field in self.config:
                 raise Exception(f'Field {field} is reserved')
 
-        self.config['root'] = path.join(os.getcwd(), os.path.dirname(self.config_file))
+        self.config['root'] = os.path.join(os.getcwd(), os.path.dirname(self.config_file))
 
         # Make build path an absolute path
         if 'build' in self.config and 'path' in self.config['build']:
@@ -44,4 +43,4 @@ class Config():
         else:
             self.config['build'] = {}
             build_path = 'build'
-        self.config['build']['path'] = path.join(self.config['root'], build_path)
+        self.config['build']['path'] = os.path.join(self.config['root'], build_path)

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,47 @@
+import os
+from os import path
+import yaml
+
+class Config():
+    def __init__(self, config_file):
+        self.config_file = config_file
+
+        if path.isfile(config_file):
+            with open(config_file, 'r') as f:
+                self.config = yaml.safe_load(f)
+        else:
+            raise Exception(f'Config file {config_file} is unexisted')
+
+        self.check_required_fields()
+        self.create_reserved_fields()
+
+    def __setitem__(self, key, value):
+        self.config[key] = value
+
+    def __getitem__(self, key):
+        return self.config[key]
+
+    def __contains__(self, key):
+        return key in self.config
+
+    def check_required_fields(self):
+        required_fields = ['process', 'tasks']
+        for field in required_fields:
+            if field not in self.config:
+                raise Exception(f'Field {field} is required in the config file')
+
+    def create_reserved_fields(self):
+        reserved_fields = ['root', 'input', 'expect']
+        for field in reserved_fields:
+            if field in self.config:
+                raise Exception(f'Field {field} is reserved')
+
+        self.config['root'] = path.join(os.getcwd(), os.path.dirname(self.config_file))
+
+        # Make build path an absolute path
+        if 'build' in self.config and 'path' in self.config['build']:
+            build_path = self.config['build']['path']
+        else:
+            self.config['build'] = {}
+            build_path = 'build'
+        self.config['build']['path'] = path.join(self.config['root'], build_path)

--- a/src/config.py
+++ b/src/config.py
@@ -30,7 +30,7 @@ class Config():
                 raise Exception(f'Field {field} is required in the config file')
 
     def create_reserved_fields(self):
-        reserved_fields = ['root', 'input', 'expect']
+        reserved_fields = ['root']
         for field in reserved_fields:
             if field in self.config:
                 raise Exception(f'Field {field} is reserved')

--- a/src/execute.py
+++ b/src/execute.py
@@ -1,4 +1,5 @@
 import subprocess
+
 import variable
 
 def for_all_commands(result):

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import argparse
+
 from process import process_tasks
 from report import report
 

--- a/src/process.py
+++ b/src/process.py
@@ -39,14 +39,11 @@ def run(config):
 
     # Process tasks
     test_result = {}
-    for i in range(len(tasks['index'])):
-        for key in tasks.keys():
-            config[key] = tasks[key][i]
+    for (index, files) in tasks:
+        for file_type, file_path in files.items():
+            config[file_type] = file_path
         (log, result) = execute_commands(config, 'process')
-        if result:
-            test_result[config['index']] = None
-        else:
-            test_result[config['index']] = log
+        test_result[index] = None if result else log
     return test_result
 
 def process_tasks(config_file):

--- a/src/process.py
+++ b/src/process.py
@@ -35,18 +35,18 @@ def run(config):
             raise SetupFailed(log)
 
     # List test cases
-    tasks = task.list_tasks(config)
+    (tasks, indices) = task.list_tasks(config)
 
     # Process tasks
     test_result = {}
-    for input, expect, id in tasks:
-        config['input'] = input
-        config['expect'] = expect
+    for i in range(len(indices)):
+        for key in tasks.keys():
+            config[key] = tasks[key][i]
         (log, result) = execute_commands(config, 'process')
         if result:
-            test_result[id] = None
+            test_result[indices[i]] = None
         else:
-            test_result[id] = log
+            test_result[indices[i]] = log
     return test_result
 
 def process_tasks(config_file):
@@ -55,6 +55,6 @@ def process_tasks(config_file):
 
     # Wrap the environment setup and teardown by a context manager
     with WorkingDirectory(config['build']['path']):
-        results = run(config)
+        return run(config)
 
-    return results
+    return {}

--- a/src/process.py
+++ b/src/process.py
@@ -1,8 +1,8 @@
-import task
-from execute import execute_commands
 import os
 import shutil
 
+import task
+from execute import execute_commands
 from config import Config
 
 class WorkingDirectory(object):

--- a/src/process.py
+++ b/src/process.py
@@ -56,5 +56,3 @@ def process_tasks(config_file):
     # Wrap the environment setup and teardown by a context manager
     with WorkingDirectory(config['build']['path']):
         return run(config)
-
-    return {}

--- a/src/process.py
+++ b/src/process.py
@@ -2,7 +2,6 @@ import task
 from execute import execute_commands
 from config import Config
 import os
-from os import path
 import shutil
 
 class WorkingDirectory(object):
@@ -10,7 +9,7 @@ class WorkingDirectory(object):
         self.working_path = working_path
 
         # Remove all files in the working directory
-        if (path.exists(working_path)):
+        if (os.path.exists(working_path)):
             shutil.rmtree(working_path)
 
         # Create clean working directory

--- a/src/process.py
+++ b/src/process.py
@@ -35,18 +35,18 @@ def run(config):
             raise SetupFailed(log)
 
     # List test cases
-    (tasks, indices) = task.list_tasks(config)
+    tasks = task.list_tasks(config)
 
     # Process tasks
     test_result = {}
-    for i in range(len(indices)):
+    for i in range(len(tasks['index'])):
         for key in tasks.keys():
             config[key] = tasks[key][i]
         (log, result) = execute_commands(config, 'process')
         if result:
-            test_result[indices[i]] = None
+            test_result[config['index']] = None
         else:
-            test_result[indices[i]] = log
+            test_result[config['index']] = log
     return test_result
 
 def process_tasks(config_file):

--- a/src/process.py
+++ b/src/process.py
@@ -1,8 +1,9 @@
 import task
 from execute import execute_commands
-from config import Config
 import os
 import shutil
+
+from config import Config
 
 class WorkingDirectory(object):
     def __init__(self, working_path):

--- a/src/task.py
+++ b/src/task.py
@@ -29,10 +29,8 @@ def build_tasks(files_info):
 
 def check_tasks(files_info):
     keys = list(files_info.keys())
-    files_mx_cnt = 0
+    files_mx_cnt = max([len(files_info[key]) for key in keys])
 
-    for key in keys:
-        files_mx_cnt = max(files_mx_cnt, len(files_info[key]))
     for i in range(files_mx_cnt):
         for j in range(1, len(keys)):
             if files_info[keys[j - 1]][i].index < files_info[keys[j]][i].index:

--- a/src/task.py
+++ b/src/task.py
@@ -23,7 +23,7 @@ def build_tasks(files_info):
     for key in keys:
         files[key] = [file.name for file in files_info[key]]
     if len(keys) > 0:
-        files["index"] = [file.index for file in files_info[keys[0]]]
+        files['index'] = [file.index for file in files_info[keys[0]]]
 
     return files
 

--- a/src/task.py
+++ b/src/task.py
@@ -1,6 +1,7 @@
-import variable
 import os
 import re
+
+import variable
 
 class IndexedFile:
     def __init__(self, index, name):

--- a/src/task.py
+++ b/src/task.py
@@ -1,5 +1,6 @@
 import os
 import re
+import more_itertools
 
 import variable
 
@@ -31,12 +32,13 @@ def check_tasks(files_info):
     keys = list(files_info.keys())
     files_mx_cnt = max([len(files_info[key]) for key in keys])
 
+    # Check that every type of file has the same index
     for i in range(files_mx_cnt):
-        for j in range(1, len(keys)):
-            if files_info[keys[j - 1]][i].index < files_info[keys[j]][i].index:
-                raise FileMiss(keys[j], files_info[keys[j - 1]][i].index)
-            elif files_info[keys[j - 1]][i].index > files_info[keys[j]][i].index:
-                raise FileMiss(keys[j - 1], files_info[keys[j]][i].index)
+        for (pre, cur) in list(more_itertools.windowed(keys, 2)):
+            if files_info[pre][i].index < files_info[cur][i].index:
+                raise FileMiss(keys[j], files_info[pre][i].index)
+            elif files_info[pre][i].index > files_info[cur][i].index:
+                raise FileMiss(pre, files_info[cur][i].index)
 
 def list_tasks(config):
     tasks = config['tasks']

--- a/src/task.py
+++ b/src/task.py
@@ -8,53 +8,54 @@ class IndexedFile:
         self.index = index
         self.name = name
 
-class InputMiss(Exception):
-    def __init__(self, expect_file):
-        super().__init__(f'Input file for {expect_file} is missing')
+    def __lt__(self, other):
+        return self.index < other.index
 
-class ExpectMiss(Exception):
-    def __init__(self, input_file):
-        super().__init__(f'Expect file for {input_file} is missing')
+class FileMiss(Exception):
+    def __init__(self, format_type, index):
+        super().__init__(f'File in "{format_type}" type with index "{index}" is missing')
 
-def expect_file(input_file, expect_hash):
-    if input_file.index in expect_hash:
-        # FIXME: the function pop() is not efficient since it will modify the hash table
-        return expect_hash.pop(input_file.index).name
-    else:
-        raise ExpectMiss(input_file.name)
+def build_tasks(files_info):
+    keys = list(files_info.keys())
+    files = {}
+    indices = []
 
-def build_tasks(input_list, expect_list):
-    expect_hash = {file.index: file for file in expect_list}
+    for key in keys:
+        files[key] = [file.name for file in files_info[key]]
+    if len(keys) > 0:
+        indices = [file.index for file in files_info[keys[0]]]
 
-    tasks = [(input.name, expect_file(input, expect_hash)) for input in input_list]
+    return (files, indices)
 
-    if len(expect_hash) != 0:
-        # pick one of the expect file
-        input_miss = list(expect_hash.values())[0]
-        raise InputMiss(input_miss.name)
+def check_tasks(files_info):
+    keys = list(files_info.keys())
+    files_mx_cnt = 0
 
-    return tasks
+    for key in keys:
+        files_mx_cnt = max(files_mx_cnt, len(files_info[key]))
+    for i in range(files_mx_cnt):
+        for j in range(1, len(keys)):
+            if files_info[keys[j - 1]][i].index < files_info[keys[j]][i].index:
+                raise FileMiss(keys[j], files_info[keys[j - 1]][i].index)
+            elif files_info[keys[j - 1]][i].index > files_info[keys[j]][i].index:
+                raise FileMiss(keys[j - 1], files_info[keys[j]][i].index)
 
 def list_tasks(config):
     tasks = config['tasks']
-    path = config['root'] + '/' + variable.solve_string(config, tasks['path'])
-    input_format = tasks['format']['input']
-    expect_format = tasks['format']['expect']
-    input_format_re = variable.solve_string(config, input_format, prefix='(', postfix=')')
-    expect_format_re = variable.solve_string(config, expect_format, prefix='(', postfix=')')
+    tasks_path = config['root'] + '/' + variable.solve_string(config, tasks['path'])
+    tasks_format = tasks['format']
 
-    files = list_files_recursively(path)
-    input_list = list_matched_files(files, input_format_re)
-    expect_list = list_matched_files(files, expect_format_re)
+    files_path = list_files_recursively(tasks_path)
+    files_info = {}
+    for format_type in tasks_format:
+        if format_type == 'index':
+            continue
+        format_re = variable.solve_string(config, tasks_format[format_type], prefix='(', postfix=')')
+        format_list = list_matched_files(files_path, format_re)
+        files_info[format_type] = sorted(format_list)
 
-    # sort input_list by index
-    input_list = sorted(input_list, key=lambda file: file.index)
-    tasks = build_tasks(input_list, expect_list)
-
-    file_format_re = '(' + variable.solve_string(config, input_format) + ')'
-    file_name = re.compile(file_format_re)
-    tasks = [(input, expect, file_name.findall(input)[0]) for input, expect in tasks]
-    return tasks
+    check_tasks(files_info)
+    return build_tasks(files_info)
 
 def list_files_recursively(path):
     result = []
@@ -65,7 +66,7 @@ def list_files_recursively(path):
     return result
 
 def list_matched_files(files, format):
-    # filter the files
+    # Filter the files
     format = re.compile(format)
     files = [file for file in files]
     indexed_files = [(file, format.findall(file)) for file in files]

--- a/src/task.py
+++ b/src/task.py
@@ -35,7 +35,7 @@ def check_tasks(files_info):
     for i in range(files_mx_cnt):
         for (pre, cur) in list(more_itertools.windowed(keys, 2)):
             if files_info[pre][i].index < files_info[cur][i].index:
-                raise FileMiss(keys[j], files_info[pre][i].index)
+                raise FileMiss(cur, files_info[pre][i].index)
             elif files_info[pre][i].index > files_info[cur][i].index:
                 raise FileMiss(pre, files_info[cur][i].index)
 

--- a/src/task.py
+++ b/src/task.py
@@ -19,14 +19,13 @@ class FileMiss(Exception):
 def build_tasks(files_info):
     keys = list(files_info.keys())
     files = {}
-    indices = []
 
     for key in keys:
         files[key] = [file.name for file in files_info[key]]
     if len(keys) > 0:
-        indices = [file.index for file in files_info[keys[0]]]
+        files["index"] = [file.index for file in files_info[keys[0]]]
 
-    return (files, indices)
+    return files
 
 def check_tasks(files_info):
     keys = list(files_info.keys())

--- a/src/task.py
+++ b/src/task.py
@@ -18,14 +18,13 @@ class FileMiss(Exception):
 
 def build_tasks(files_info):
     keys = list(files_info.keys())
-    files = {}
+    indices = [file.index for file in files_info[keys[0]]] if len(keys) > 0 else []
+    tasks = []
 
-    for key in keys:
-        files[key] = [file.name for file in files_info[key]]
-    if len(keys) > 0:
-        files['index'] = [file.index for file in files_info[keys[0]]]
+    for i, index in enumerate(indices):
+        tasks.append((index, {key: files_info[key][i].name for key in keys}))
 
-    return files
+    return tasks
 
 def check_tasks(files_info):
     keys = list(files_info.keys())

--- a/test/test.py
+++ b/test/test.py
@@ -33,7 +33,7 @@ class Test(unittest.TestCase):
         # Traverse the value of report
         # Assert that all values are None except the "input_5"
         for testcase, result in results.items():
-            if 'input_5' in testcase:
+            if '5' in testcase:
                 self.assertNotEqual(result, None, result)
             else:
                 self.assertEqual(result, None, result)
@@ -46,20 +46,20 @@ class Test(unittest.TestCase):
             process_tasks('compile_error/judge.yaml')
 
     def test_missing_input(self):
-        from task import InputMiss
-        with self.assertRaises(InputMiss) as raised:
+        from task import FileMiss
+        with self.assertRaises(FileMiss) as raised:
             process_tasks('missing_input/judge.yaml')
-        expect = re.compile("Input file for .*missing_input/testcases/output_1.txt is missing")
+        expect = "task.FileMiss: File in \"input\" type with index \"1\" is missing"
         message = f'{raised.exception}'
-        self.assertIsNotNone(expect.match(message), message)
+        self.assertIsNotNone(expect, message)
 
     def test_missing_expect(self):
-        from task import ExpectMiss
-        with self.assertRaises(ExpectMiss) as raised:
-            process_tasks('missing_expect/judge.yaml')
-        expect = re.compile("Expect file for .*missing_expect/testcases/input_1.txt is missing")
+        from task import FileMiss
+        with self.assertRaises(FileMiss) as raised:
+            process_tasks('missing_input/judge.yaml')
+        expect = "task.FileMiss: File in \"expect\" type with index \"1\" is missing"
         message = f'{raised.exception}'
-        self.assertIsNotNone(expect.match(message), message)
+        self.assertIsNotNone(expect, message)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -49,17 +49,17 @@ class Test(unittest.TestCase):
         from task import FileMiss
         with self.assertRaises(FileMiss) as raised:
             process_tasks('missing_input/judge.yaml')
-        expect = "task.FileMiss: File in \"input\" type with index \"1\" is missing"
-        message = f'{raised.exception}'
-        self.assertIsNotNone(expect, message)
+        expect_message = 'File in "input" type with index "1" is missing'
+        exception_message = f'{raised.exception}'
+        self.assertEqual(expect_message, exception_message)
 
     def test_missing_expect(self):
         from task import FileMiss
         with self.assertRaises(FileMiss) as raised:
-            process_tasks('missing_input/judge.yaml')
-        expect = "task.FileMiss: File in \"expect\" type with index \"1\" is missing"
-        message = f'{raised.exception}'
-        self.assertIsNotNone(expect, message)
+            process_tasks('missing_expect/judge.yaml')
+        expect_message = 'File in "expect" type with index "1" is missing'
+        exception_message = f'{raised.exception}'
+        self.assertEqual(expect_message, exception_message)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Make the environment setup in a context manager, might not rawly handle it in `main()` anymore.
- Move `config` checking and preprocessing in class, and also make `config` supply the feature of `dict` type.
- Unify the `import` rule. Split local and public package, and also `os.path` and `path` may not use simultaneously. 
- There may have lots of formats in `tasks` area, not only `input` and `expect`, so it's not relational to hardcode the handle of any specific `tasks` format in source code. Make PECO more flexible to extended `tasks`.

---

The unit test has a little change after refactorment. I have checked both unit test and example run well.