### PR TITLE
Update logging format for system error

### DIFF
--- a/src/execute.py
+++ b/src/execute.py
@@ -10,7 +10,7 @@ def without_fail(result):
 
 def default_logger(result):
     if isinstance(result, str):
-        return result
+        return {'system': result}
     else:
         return {'stdout': result.stdout, 'stderr': result.stderr}
 

--- a/src/report.py
+++ b/src/report.py
@@ -39,13 +39,10 @@ def report(results, verbose=True):
                 for command, outcome in log.items():
                     report += '-' * length + '\n'
                     report += f'{shader(command, COMMAND, verbose)}: \n'
-                    if outcome['stdout'] != b'':
-                        report += f'{shader("stdout:", OUTCOME, verbose)}\n'
-                        report += f'{outcome["stdout"].decode()}\n'
-                        report += '\n'
-                    if outcome["stderr"] != b'':
-                        report += f'{shader("stderr:", OUTCOME, verbose)}\n'
-                        report += f'{outcome["stderr"].decode()}\n'
+                    for key, value in outcome.items():
+                        report += f'{shader(key, OUTCOME, verbose)}\n'
+                        value = value.decode() if isinstance(value, bytes) else value
+                        report += f'{value}\n'
                         report += '\n'
             report += '=' * length + '\n\n'
     # Conclude the report with a summary (Failed / Total)


### PR DESCRIPTION
The mismatch between normal log and system log will cause report.py failed Update the format for system log to as same as normal log